### PR TITLE
OFZ-7 feat: 메인 페이지 작업 중간 반영

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7663,7 +7663,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -8353,7 +8353,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=8"
       },
@@ -8514,7 +8514,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -8910,7 +8910,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -8934,7 +8934,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -11890,7 +11890,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -13072,6 +13072,13 @@
         "node": ">=16.x"
       }
     },
+    "node_modules/immutable": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.6.tgz",
+      "integrity": "sha512-Ju0+lEMyzMVZarkTn/gqRpdqd5dOPaz1mCZ0SH3JV6iFw81PldE/PEB1hWVEA288HPt4WXW8O7AWxB10M+03QQ==",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -13255,7 +13262,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -13358,7 +13365,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13412,7 +13419,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -13482,7 +13489,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -15724,7 +15731,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16415,7 +16422,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -17388,7 +17395,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -17915,6 +17922,24 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "node_modules/sass": {
+      "version": "1.77.8",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.8.tgz",
+      "integrity": "sha512-4UHg6prsrycW20fqLGPShtEvo/WyHRVRHwOP4DzkUrObWoWI05QBSfzU71TVB7PFaL104TwNaHpjlWXAZbQiNQ==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "chokidar": ">=3.0.0 <4.0.0",
+        "immutable": "^4.0.0",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/sass-loader": {
       "version": "12.6.0",
@@ -19320,7 +19345,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -20553,9 +20578,9 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
-      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"

--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -1,232 +1,113 @@
 .main {
+  width: 100%;
+  height: 100%;
+  position: relative;
+}
+
+.first-main {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  padding-left: 11.44rem;
+  position: relative;
+}
+
+.first-main-text {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.first-main-title {
+  margin-bottom: 1.875rem;
+}
+
+.first-main-text div {
+  margin-bottom: 1.75rem;
+}
+
+.first-main-image-wrapper {
+  position: absolute;
+  right: 0;
+  width: 50%;
+  height: 100vh;
+}
+
+.first-main-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.second-main {
+  width: 100%;
+  height: 100vh;
+  margin-top: 5.25rem;
+  margin-bottom: 6.625rem;
+  position: relative;
   display: flex;
   flex-direction: column;
+  text-align: center;
+}
+
+.second-main-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--blue-main);
+  text-align: center;
+  margin-bottom: 1.25rem;
+  font-family: Figtree;
+}
+
+.second-main-image-wrapper {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  margin-top: 4rem;
+}
+
+.second-main-image {
+  width: 73%;
+  height: 58%;
+  border-radius: 1.91206rem;
+  object-fit: cover;
+  box-shadow: 0px 3.824px 42.065px 0px rgba(0, 0, 0, 0.08);
+}
+
+.third-main {
+  width: 100%;
+  height: 100vh;
+  position: relative;
+  display: flex;
+  background-color: var(--blue-greyish);
   justify-content: space-between;
   align-items: center;
-  padding: 6rem;
-  min-height: 100vh;
 }
 
-.description {
-  display: inherit;
-  justify-content: inherit;
-  align-items: inherit;
-  font-size: 0.85rem;
-  max-width: var(--max-width);
-  width: 100%;
-  z-index: 2;
-  font-family: var(--font-mono);
-}
-
-.description a {
+.third-main-content {
+  width: 73%;
+  height: 64%;
   display: flex;
-  justify-content: center;
+  justify-content: space-between;
   align-items: center;
-  gap: 0.5rem;
-}
-
-.description p {
-  position: relative;
-  margin: 0;
-  padding: 1rem;
-  background-color: rgba(var(--callout-rgb), 0.5);
-  border: 1px solid rgba(var(--callout-border-rgb), 0.3);
-  border-radius: var(--border-radius);
-}
-
-.code {
-  font-weight: 700;
-  font-family: var(--font-mono);
-}
-
-.grid {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(25%, auto));
-  max-width: 100%;
-  width: var(--max-width);
-}
-
-.card {
-  padding: 1rem 1.2rem;
-  border-radius: var(--border-radius);
-  background: rgba(var(--card-rgb), 0);
-  border: 1px solid rgba(var(--card-border-rgb), 0);
-  transition:
-    background 200ms,
-    border 200ms;
-}
-
-.card span {
-  display: inline-block;
-  transition: transform 200ms;
-}
-
-.card h2 {
-  font-weight: 600;
-  margin-bottom: 0.7rem;
-}
-
-.card p {
-  margin: 0;
-  opacity: 0.6;
-  font-size: 0.9rem;
-  line-height: 1.5;
-  max-width: 30ch;
-  text-wrap: balance;
-}
-
-.center {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  position: relative;
-  padding: 4rem 0;
-}
-
-.center::before {
-  background: var(--secondary-glow);
-  border-radius: 50%;
-  width: 480px;
-  height: 360px;
-  margin-left: -400px;
-}
-
-.center::after {
-  background: var(--primary-glow);
-  width: 240px;
-  height: 180px;
-  z-index: -1;
-}
-
-.center::before,
-.center::after {
-  content: '';
-  left: 50%;
   position: absolute;
-  filter: blur(45px);
-  transform: translateZ(0);
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
 }
 
-.logo {
-  position: relative;
-}
-/* Enable hover only on non-touch devices */
-@media (hover: hover) and (pointer: fine) {
-  .card:hover {
-    background: rgba(var(--card-rgb), 0.1);
-    border: 1px solid rgba(var(--card-border-rgb), 0.15);
-  }
-
-  .card:hover span {
-    transform: translateX(4px);
-  }
+.third-main-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--blue-main);
+  font-family: Figtree;
+  margin-bottom: 1.25rem;
 }
 
-@media (prefers-reduced-motion) {
-  .card:hover span {
-    transform: none;
-  }
-}
-
-/* Mobile */
-@media (max-width: 700px) {
-  .content {
-    padding: 4rem;
-  }
-
-  .grid {
-    grid-template-columns: 1fr;
-    margin-bottom: 120px;
-    max-width: 320px;
-    text-align: center;
-  }
-
-  .card {
-    padding: 1rem 2.5rem;
-  }
-
-  .card h2 {
-    margin-bottom: 0.5rem;
-  }
-
-  .center {
-    padding: 8rem 0 6rem;
-  }
-
-  .center::before {
-    transform: none;
-    height: 300px;
-  }
-
-  .description {
-    font-size: 0.8rem;
-  }
-
-  .description a {
-    padding: 1rem;
-  }
-
-  .description p,
-  .description div {
-    display: flex;
-    justify-content: center;
-    position: fixed;
-    width: 100%;
-  }
-
-  .description p {
-    align-items: center;
-    inset: 0 0 auto;
-    padding: 2rem 1rem 1.4rem;
-    border-radius: 0;
-    border: none;
-    border-bottom: 1px solid rgba(var(--callout-border-rgb), 0.25);
-    background: linear-gradient(
-      to bottom,
-      rgba(var(--background-start-rgb), 1),
-      rgba(var(--callout-rgb), 0.5)
-    );
-    background-clip: padding-box;
-    backdrop-filter: blur(24px);
-  }
-
-  .description div {
-    align-items: flex-end;
-    pointer-events: none;
-    inset: auto 0 0;
-    padding: 2rem;
-    height: 200px;
-    background: linear-gradient(
-      to bottom,
-      transparent 0%,
-      rgb(var(--background-end-rgb)) 40%
-    );
-    z-index: 1;
-  }
-}
-
-/* Tablet and Smaller Desktop */
-@media (min-width: 701px) and (max-width: 1120px) {
-  .grid {
-    grid-template-columns: repeat(2, 50%);
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  .vercelLogo {
-    filter: invert(1);
-  }
-
-  .logo {
-    filter: invert(1) drop-shadow(0 0 0.3rem #ffffff70);
-  }
-}
-
-@keyframes rotate {
-  from {
-    transform: rotate(360deg);
-  }
-  to {
-    transform: rotate(0deg);
-  }
+.third-main-image {
+  width: 60%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 1.75rem;
+  box-shadow: 0px 3.824px 42.065px 0px rgba(0, 0, 0, 0.08);
 }

--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -50,11 +50,10 @@
   text-align: center;
 }
 
-.second-main-title {
+.main-index {
   font-size: 1.25rem;
   font-weight: 600;
   color: var(--blue-main);
-  text-align: center;
   margin-bottom: 1.25rem;
   font-family: Figtree;
 }
@@ -96,18 +95,41 @@
   transform: translate(-50%, -50%);
 }
 
-.third-main-title {
-  font-size: 1.25rem;
-  font-weight: 600;
-  color: var(--blue-main);
-  font-family: Figtree;
-  margin-bottom: 1.25rem;
-}
-
 .third-main-image {
   width: 60%;
   height: 100%;
   object-fit: cover;
   border-radius: 1.75rem;
   box-shadow: 0px 3.824px 42.065px 0px rgba(0, 0, 0, 0.08);
+}
+
+.fourth-main {
+  width: 100%;
+  height: 100vh;
+  position: relative;
+  padding: 0 11.44rem;
+}
+
+.fourth-main-image {
+  width: 53%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.fourth-main-sub-image {
+  width: 53%;
+  height: 25%;
+  object-fit: cover;
+  border-radius: 2rem;
+  border: 1px solid #ededed;
+  box-shadow: 0px 8px 44px 0px rgba(0, 0, 0, 0.04);
+  position: absolute;
+  top: 8.5rem;
+  left: 28.81rem;
+}
+
+.fourth-main-text {
+  position: absolute;
+  bottom: 6.13rem;
+  right: 11.44rem;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image';
 import Header from '@/components/Header';
 import thumbnail from '../../public/thumbnail.png';
 import TitleDesc from '@/components/TitleDesc';
-import { DASHBOARD_MAIN, TOP_MAIN } from '@/constants/main';
+import { DASHBOARD_MAIN, TODO_MAIN, TOP_MAIN } from '@/constants/main';
 import Button from '@/components/Button';
 
 export default function MainPage() {
@@ -71,8 +71,9 @@ export default function MainPage() {
           id="second-main"
           style={{
             width: '100%',
-            height: '100%',
+            height: '100vh',
             marginTop: '5.25rem',
+            marginBottom: '6.625rem',
             position: 'relative',
             display: 'flex',
             flexDirection: 'column',
@@ -86,6 +87,7 @@ export default function MainPage() {
               color: 'var(--blue-main)',
               textAlign: 'center',
               marginBottom: '1.25rem',
+              fontFamily: 'Figtree',
             }}
           >
             {DASHBOARD_MAIN.index}
@@ -98,6 +100,8 @@ export default function MainPage() {
           <div
             id="second-main-image"
             style={{
+              width: '100%',
+              height: '100%',
               position: 'relative',
               marginTop: '4rem',
             }}
@@ -106,14 +110,71 @@ export default function MainPage() {
               src={thumbnail}
               alt="임시 이미지"
               style={{
-                width: '62.5rem',
-                height: '36.25rem',
+                width: '73%',
+                height: '58%',
                 borderRadius: '1.91206rem',
                 objectFit: 'cover',
-                marginBottom: '6.62rem',
+                boxShadow: '0px 3.824px 42.065px 0px rgba(0, 0, 0, 0.08)',
               }}
             />
           </div>
+        </section>
+        <section
+          id="third-main"
+          style={{
+            width: '100%',
+            height: '100vh',
+            position: 'relative',
+            display: 'flex',
+            backgroundColor: 'var(--blue-greyish)',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+          }}
+        >
+          <section
+            id="third-main-content"
+            style={{
+              width: '73%',
+              height: '64%',
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              position: 'absolute',
+              top: '50%',
+              left: '50%',
+              transform: 'translate(-50%, -50%)',
+            }}
+          >
+            <section id="third-main-text">
+              <p
+                style={{
+                  fontSize: '1.25rem',
+                  fontWeight: '600',
+                  color: 'var(--blue-main)',
+                  fontFamily: 'Figtree',
+                  marginBottom: '1.25rem',
+                }}
+              >
+                {TODO_MAIN.index}
+              </p>
+              <TitleDesc
+                title={TODO_MAIN.title}
+                desc={TODO_MAIN.desc}
+                sort="left"
+              />
+            </section>
+            <Image
+              src={thumbnail}
+              alt="임시 이미지"
+              style={{
+                width: '60%',
+                height: '100%',
+                objectFit: 'cover',
+                borderRadius: '1.75rem',
+                boxShadow: '0px 3.824px 42.065px 0px rgba(0, 0, 0, 0.08)',
+              }}
+            />
+          </section>
         </section>
       </main>
     </>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -53,7 +53,7 @@ export default function MainPage() {
               position: 'absolute',
               right: '0',
               width: '50%',
-              height: '48rem',
+              height: '100vh',
             }}
           >
             <Image

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,12 @@ import Image from 'next/image';
 import Header from '@/components/Header';
 import thumbnail from '../../public/thumbnail.png';
 import TitleDesc from '@/components/TitleDesc';
-import { DASHBOARD_MAIN, TODO_MAIN, TOP_MAIN } from '@/constants/main';
+import {
+  DASHBOARD_MAIN,
+  RETROSPECT_MAIN,
+  TODO_MAIN,
+  TOP_MAIN,
+} from '@/constants/main';
 import Button from '@/components/Button';
 import { Fragment } from 'react';
 import styles from './page.module.css';
@@ -42,7 +47,9 @@ export default function MainPage() {
           </div>
         </section>
         <section className={styles['second-main']}>
-          <p className={styles['second-main-title']}>{DASHBOARD_MAIN.index}</p>
+          <p className={styles['main-index']} style={{ textAlign: 'center' }}>
+            {DASHBOARD_MAIN.index}
+          </p>
           <TitleDesc
             title={DASHBOARD_MAIN.title}
             desc={DASHBOARD_MAIN.desc}
@@ -59,7 +66,7 @@ export default function MainPage() {
         <section className={styles['third-main']}>
           <section className={styles['third-main-content']}>
             <section id="third-main-text">
-              <p className={styles['third-main-title']}>{TODO_MAIN.index}</p>
+              <p className={styles['main-index']}>{TODO_MAIN.index}</p>
               <TitleDesc
                 title={TODO_MAIN.title}
                 desc={TODO_MAIN.desc}
@@ -70,6 +77,26 @@ export default function MainPage() {
               src={thumbnail}
               alt="임시 이미지"
               className={styles['third-main-image']}
+            />
+          </section>
+        </section>
+        <section className={styles['fourth-main']}>
+          <Image
+            src={thumbnail}
+            alt="임시 이미지"
+            className={styles['fourth-main-image']}
+          />
+          <Image
+            src={thumbnail}
+            alt="임시 서브 이미지"
+            className={styles['fourth-main-sub-image']}
+          />
+          <section className={styles['fourth-main-text']}>
+            <p className={styles['main-index']}>{RETROSPECT_MAIN.index}</p>
+            <TitleDesc
+              title={RETROSPECT_MAIN.title}
+              desc={RETROSPECT_MAIN.desc}
+              sort="left"
             />
           </section>
         </section>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Image from 'next/image';
+import { Fragment } from 'react';
 import Header from '@/components/Header';
 import thumbnail from '../../public/thumbnail.png';
 import TitleDesc from '@/components/TitleDesc';
@@ -11,12 +12,11 @@ import {
   TOP_MAIN,
 } from '@/constants/main';
 import Button from '@/components/Button';
-import { Fragment } from 'react';
 import styles from './page.module.css';
 
 export default function MainPage() {
   return (
-    <Fragment>
+    <>
       <Header />
       <main className={styles.main}>
         <section className={styles['first-main']}>
@@ -101,6 +101,6 @@ export default function MainPage() {
           </section>
         </section>
       </main>
-    </Fragment>
+    </>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,32 +6,18 @@ import thumbnail from '../../public/thumbnail.png';
 import TitleDesc from '@/components/TitleDesc';
 import { DASHBOARD_MAIN, TODO_MAIN, TOP_MAIN } from '@/constants/main';
 import Button from '@/components/Button';
+import { Fragment } from 'react';
+import styles from './page.module.css';
 
 export default function MainPage() {
   return (
-    <>
+    <Fragment>
       <Header />
-      <main style={{ width: '100%', height: '100%', position: 'relative' }}>
-        <section
-          id="first-main"
-          style={{
-            width: '100%',
-            height: '100%',
-            display: 'flex',
-            paddingLeft: '11.44rem',
-            position: 'relative',
-          }}
-        >
-          <section
-            id="first-main-text"
-            style={{
-              position: 'absolute',
-              top: '50%',
-              transform: 'translateY(-50%)',
-            }}
-          >
-            <p style={{ marginBottom: '1.875rem' }}>{TOP_MAIN.slogan}</p>
-            <div id="title-desc-wrapper" style={{ marginBottom: '1.75rem' }}>
+      <main className={styles.main}>
+        <section className={styles['first-main']}>
+          <section className={styles['first-main-text']}>
+            <p className={styles['first-main-title']}>{TOP_MAIN.slogan}</p>
+            <div id="title-desc-wrapper">
               <TitleDesc
                 title={TOP_MAIN.title}
                 desc={TOP_MAIN.desc}
@@ -47,116 +33,33 @@ export default function MainPage() {
               hoverColor="var(--blue-dark)"
             />
           </section>
-          <div
-            id="first-main-image"
-            style={{
-              position: 'absolute',
-              right: '0',
-              width: '50%',
-              height: '100vh',
-            }}
-          >
+          <div className={styles['first-main-image-wrapper']}>
             <Image
               src={thumbnail}
               alt="서비스 메인 이미지"
-              style={{
-                width: '100%',
-                height: '100%',
-                objectFit: 'cover',
-              }}
+              className={styles['first-main-image']}
             />
           </div>
         </section>
-        <section
-          id="second-main"
-          style={{
-            width: '100%',
-            height: '100vh',
-            marginTop: '5.25rem',
-            marginBottom: '6.625rem',
-            position: 'relative',
-            display: 'flex',
-            flexDirection: 'column',
-            textAlign: 'center',
-          }}
-        >
-          <p
-            style={{
-              fontSize: '1.25rem',
-              fontWeight: '600',
-              color: 'var(--blue-main)',
-              textAlign: 'center',
-              marginBottom: '1.25rem',
-              fontFamily: 'Figtree',
-            }}
-          >
-            {DASHBOARD_MAIN.index}
-          </p>
+        <section className={styles['second-main']}>
+          <p className={styles['second-main-title']}>{DASHBOARD_MAIN.index}</p>
           <TitleDesc
             title={DASHBOARD_MAIN.title}
             desc={DASHBOARD_MAIN.desc}
             sort="center"
           />
-          <div
-            id="second-main-image"
-            style={{
-              width: '100%',
-              height: '100%',
-              position: 'relative',
-              marginTop: '4rem',
-            }}
-          >
+          <div className={styles['second-main-image-wrapper']}>
             <Image
               src={thumbnail}
               alt="임시 이미지"
-              style={{
-                width: '73%',
-                height: '58%',
-                borderRadius: '1.91206rem',
-                objectFit: 'cover',
-                boxShadow: '0px 3.824px 42.065px 0px rgba(0, 0, 0, 0.08)',
-              }}
+              className={styles['second-main-image']}
             />
           </div>
         </section>
-        <section
-          id="third-main"
-          style={{
-            width: '100%',
-            height: '100vh',
-            position: 'relative',
-            display: 'flex',
-            backgroundColor: 'var(--blue-greyish)',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-          }}
-        >
-          <section
-            id="third-main-content"
-            style={{
-              width: '73%',
-              height: '64%',
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'center',
-              position: 'absolute',
-              top: '50%',
-              left: '50%',
-              transform: 'translate(-50%, -50%)',
-            }}
-          >
+        <section className={styles['third-main']}>
+          <section className={styles['third-main-content']}>
             <section id="third-main-text">
-              <p
-                style={{
-                  fontSize: '1.25rem',
-                  fontWeight: '600',
-                  color: 'var(--blue-main)',
-                  fontFamily: 'Figtree',
-                  marginBottom: '1.25rem',
-                }}
-              >
-                {TODO_MAIN.index}
-              </p>
+              <p className={styles['third-main-title']}>{TODO_MAIN.index}</p>
               <TitleDesc
                 title={TODO_MAIN.title}
                 desc={TODO_MAIN.desc}
@@ -166,17 +69,11 @@ export default function MainPage() {
             <Image
               src={thumbnail}
               alt="임시 이미지"
-              style={{
-                width: '60%',
-                height: '100%',
-                objectFit: 'cover',
-                borderRadius: '1.75rem',
-                boxShadow: '0px 3.824px 42.065px 0px rgba(0, 0, 0, 0.08)',
-              }}
+              className={styles['third-main-image']}
             />
           </section>
         </section>
       </main>
-    </>
+    </Fragment>
   );
 }

--- a/src/components/Badge/Badge.stories.ts
+++ b/src/components/Badge/Badge.stories.ts
@@ -1,0 +1,19 @@
+import { Meta, StoryObj } from '@storybook/react';
+import Badge from '.';
+
+const meta = {
+  title: 'Badge',
+  component: Badge,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+  args: {
+    text: '독립 오피스',
+  },
+} satisfies Meta<typeof Badge>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {};

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -7,7 +7,20 @@ function Badge(props: BadgeProps) {
     color = 'var(--blue-dark)',
   } = props;
 
-  return <div>{text}</div>;
+  return (
+    <div
+      style={{
+        width: 'max-content',
+        height: '1.625rem',
+        padding: '0.25rem 0.5rem',
+        borderRadius: '0.5rem',
+        backgroundColor,
+        color,
+      }}
+    >
+      {text}
+    </div>
+  );
 }
 
 export default Badge;

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -1,0 +1,13 @@
+import { BadgeProps } from '@/types/badge.type';
+
+function Badge(props: BadgeProps) {
+  const {
+    text,
+    backgroundColor = 'var(--blue-greyish)',
+    color = 'var(--blue-dark)',
+  } = props;
+
+  return <div>{text}</div>;
+}
+
+export default Badge;

--- a/src/components/Badge/index.tsx
+++ b/src/components/Badge/index.tsx
@@ -1,0 +1,3 @@
+import Badge from './Badge';
+
+export default Badge;

--- a/src/components/Info/OfficeInfo/OfficeInfo.stories.ts
+++ b/src/components/Info/OfficeInfo/OfficeInfo.stories.ts
@@ -1,0 +1,19 @@
+import { Meta, StoryObj } from '@storybook/react';
+import OfficeInfo from '.';
+
+const meta = {
+  title: 'OfficeInfo',
+  component: OfficeInfo,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+  args: {
+    placeName: '임시 오피스명',
+  },
+} satisfies Meta<typeof OfficeInfo>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {};

--- a/src/components/Info/OfficeInfo/OfficeInfo.styled.ts
+++ b/src/components/Info/OfficeInfo/OfficeInfo.styled.ts
@@ -1,3 +1,12 @@
 import styled from 'styled-components';
 
-export const OfficeInfoContainer = styled.div``;
+export const OfficeInfoContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+
+  #badge-container {
+    display: flex;
+    gap: 1rem;
+  }
+`;

--- a/src/components/Info/OfficeInfo/OfficeInfo.styled.ts
+++ b/src/components/Info/OfficeInfo/OfficeInfo.styled.ts
@@ -1,0 +1,3 @@
+import styled from 'styled-components';
+
+export const OfficeInfoContainer = styled.div``;

--- a/src/components/Info/OfficeInfo/OfficeInfo.tsx
+++ b/src/components/Info/OfficeInfo/OfficeInfo.tsx
@@ -1,0 +1,20 @@
+import { OfficeInfoProps } from '@/types/info/officeInfo.type';
+import { OfficeInfoContainer } from './OfficeInfo.styled';
+
+function OfficeInfo(props: OfficeInfoProps) {
+  const {
+    placeName,
+    officeType = '분류없음',
+    dayAndNight = '미등록',
+    price = '가격미정',
+    priceUnit = '미정',
+  } = props;
+
+  return (
+    <OfficeInfoContainer>
+      <h3>{placeName}</h3>
+    </OfficeInfoContainer>
+  );
+}
+
+export default OfficeInfo;

--- a/src/components/Info/OfficeInfo/OfficeInfo.tsx
+++ b/src/components/Info/OfficeInfo/OfficeInfo.tsx
@@ -1,18 +1,25 @@
 import { OfficeInfoProps } from '@/types/info/officeInfo.type';
 import { OfficeInfoContainer } from './OfficeInfo.styled';
+import Badge from '@/components/Badge';
+import PriceUnit from '@/components/PriceUnit';
 
 function OfficeInfo(props: OfficeInfoProps) {
   const {
     placeName,
     officeType = '분류없음',
     dayAndNight = '미등록',
-    price = '가격미정',
+    price = 0,
     priceUnit = '미정',
   } = props;
 
   return (
     <OfficeInfoContainer>
       <h3>{placeName}</h3>
+      <div id="badge-container">
+        <Badge text={officeType} />
+        <Badge text={dayAndNight} />
+      </div>
+      <PriceUnit price={price} unit={priceUnit} />
     </OfficeInfoContainer>
   );
 }

--- a/src/components/Info/OfficeInfo/index.tsx
+++ b/src/components/Info/OfficeInfo/index.tsx
@@ -1,0 +1,3 @@
+import OfficeInfo from './OfficeInfo';
+
+export default OfficeInfo;

--- a/src/components/PriceUnit/PriceUnit.stories.ts
+++ b/src/components/PriceUnit/PriceUnit.stories.ts
@@ -1,0 +1,20 @@
+import { Meta, StoryObj } from '@storybook/react';
+import PriceUnit from '.';
+
+const meta = {
+  title: 'PriceUnit',
+  component: PriceUnit,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+  args: {
+    price: 80000,
+    unit: '일',
+  },
+} satisfies Meta<typeof PriceUnit>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {};

--- a/src/components/PriceUnit/PriceUnit.styled.ts
+++ b/src/components/PriceUnit/PriceUnit.styled.ts
@@ -1,0 +1,18 @@
+import styled from 'styled-components';
+
+export const PriceUnitContainer = styled.div`
+  width: max-content;
+  height: 1.75rem;
+
+  #price {
+    color: var(--blue-main);
+    font-size: 1.25rem;
+    font-weight: 600;
+    line-height: 1.75rem;
+  }
+
+  #unit {
+    font-weight: 400;
+    line-height: 1.375rem;
+  }
+`;

--- a/src/components/PriceUnit/PriceUnit.tsx
+++ b/src/components/PriceUnit/PriceUnit.tsx
@@ -1,9 +1,15 @@
 import { PriceUnitProps } from '@/types/priceUnit.type';
+import { PriceUnitContainer } from './PriceUnit.styled';
 
 function PriceUnit(props: PriceUnitProps) {
   const { price, unit } = props;
 
-  return <div>Price</div>;
+  return (
+    <PriceUnitContainer>
+      <span id="price">{price.toLocaleString()}원&nbsp;</span>
+      <span id="unit">/&nbsp;{unit}</span>
+    </PriceUnitContainer>
+  );
 }
 
 export default PriceUnit;

--- a/src/components/PriceUnit/PriceUnit.tsx
+++ b/src/components/PriceUnit/PriceUnit.tsx
@@ -1,0 +1,9 @@
+import { PriceUnitProps } from '@/types/priceUnit.type';
+
+function PriceUnit(props: PriceUnitProps) {
+  const { price, unit } = props;
+
+  return <div>Price</div>;
+}
+
+export default PriceUnit;

--- a/src/components/PriceUnit/index.tsx
+++ b/src/components/PriceUnit/index.tsx
@@ -1,0 +1,3 @@
+import PriceUnit from './PriceUnit';
+
+export default PriceUnit;

--- a/src/components/ScrollSlider/ScrollSlider.stories.ts
+++ b/src/components/ScrollSlider/ScrollSlider.stories.ts
@@ -1,0 +1,16 @@
+import { Meta, StoryObj } from '@storybook/react';
+import ScrollSlider from '.';
+
+const meta = {
+  title: 'ScrollSlider',
+  component: ScrollSlider,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof ScrollSlider>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {};

--- a/src/components/ScrollSlider/ScrollSlider.tsx
+++ b/src/components/ScrollSlider/ScrollSlider.tsx
@@ -1,0 +1,5 @@
+function ScrollSlider() {
+  return <div>test</div>;
+}
+
+export default ScrollSlider;

--- a/src/components/ScrollSlider/index.tsx
+++ b/src/components/ScrollSlider/index.tsx
@@ -1,0 +1,3 @@
+import ScrollSlider from './ScrollSlider';
+
+export default ScrollSlider;

--- a/src/components/StatefulTitleDesc/StatefulTitleDesc.stories.ts
+++ b/src/components/StatefulTitleDesc/StatefulTitleDesc.stories.ts
@@ -1,0 +1,16 @@
+import { Meta, StoryObj } from '@storybook/react';
+import StatefulTitleDesc from '.';
+
+const meta = {
+  title: 'StatefulTitleDesc',
+  component: StatefulTitleDesc,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof StatefulTitleDesc>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {};

--- a/src/components/StatefulTitleDesc/StatefulTitleDesc.stories.ts
+++ b/src/components/StatefulTitleDesc/StatefulTitleDesc.stories.ts
@@ -8,6 +8,11 @@ const meta = {
   parameters: {
     layout: 'fullscreen',
   },
+  args: {
+    title: 'title',
+    desc: 'description',
+    state: 'active',
+  },
 } satisfies Meta<typeof StatefulTitleDesc>;
 
 export default meta;

--- a/src/components/StatefulTitleDesc/StatefulTitleDesc.styled.ts
+++ b/src/components/StatefulTitleDesc/StatefulTitleDesc.styled.ts
@@ -1,0 +1,21 @@
+import { TextState } from '@/types/statefulTitleDesc.type';
+import styled from 'styled-components';
+
+export const StatefulTitleDescContainer = styled.div<{ $state: TextState }>`
+  height: 3.5rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  #stateful-title {
+    font-family: 'Figtree';
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: ${(props) =>
+      props.$state === 'active' ? 'var(--blue-main)' : 'var(--black-main)'};
+  }
+
+  #stateful-desc {
+    color: var(--black-400);
+  }
+`;

--- a/src/components/StatefulTitleDesc/StatefulTitleDesc.styled.ts
+++ b/src/components/StatefulTitleDesc/StatefulTitleDesc.styled.ts
@@ -1,5 +1,5 @@
-import { TextState } from '@/types/statefulTitleDesc.type';
 import styled from 'styled-components';
+import { TextState } from '@/types/statefulTitleDesc.type';
 
 export const StatefulTitleDescContainer = styled.div<{ $state: TextState }>`
   height: 3.5rem;

--- a/src/components/StatefulTitleDesc/StatefulTitleDesc.tsx
+++ b/src/components/StatefulTitleDesc/StatefulTitleDesc.tsx
@@ -1,5 +1,15 @@
-function StatefulTitleDesc() {
-  return <p>stateful</p>;
+import { StatefulTitleDescProps } from '@/types/statefulTitleDesc.type';
+import { StatefulTitleDescContainer } from './StatefulTitleDesc.styled';
+
+function StatefulTitleDesc(props: StatefulTitleDescProps) {
+  const { title, desc, state } = props;
+
+  return (
+    <StatefulTitleDescContainer $state={state}>
+      <p id="stateful-title">{title}</p>
+      <p id="stateful-desc">{desc}</p>
+    </StatefulTitleDescContainer>
+  );
 }
 
 export default StatefulTitleDesc;

--- a/src/components/StatefulTitleDesc/StatefulTitleDesc.tsx
+++ b/src/components/StatefulTitleDesc/StatefulTitleDesc.tsx
@@ -1,0 +1,5 @@
+function StatefulTitleDesc() {
+  return <p>stateful</p>;
+}
+
+export default StatefulTitleDesc;

--- a/src/components/StatefulTitleDesc/index.tsx
+++ b/src/components/StatefulTitleDesc/index.tsx
@@ -1,0 +1,3 @@
+import StatefulTitleDesc from './StatefulTitleDesc';
+
+export default StatefulTitleDesc;

--- a/src/components/Thumbnail/Thumbnail.stories.ts
+++ b/src/components/Thumbnail/Thumbnail.stories.ts
@@ -1,0 +1,21 @@
+import { Meta, StoryObj } from '@storybook/react';
+import Thumbnail from '.';
+import thumbnail from '../../../public/thumbnail.png';
+
+const meta = {
+  title: 'Thumbnail',
+  component: Thumbnail,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+  args: {
+    src: thumbnail,
+    alt: '임시 이미지',
+  },
+} satisfies Meta<typeof Thumbnail>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {};

--- a/src/components/Thumbnail/Thumbnail.tsx
+++ b/src/components/Thumbnail/Thumbnail.tsx
@@ -1,5 +1,5 @@
-import { ThumbnailProps } from '@/types/thumbnail.type';
 import Image from 'next/image';
+import { ThumbnailProps } from '@/types/thumbnail.type';
 
 function Thumbnail(props: ThumbnailProps) {
   const {

--- a/src/components/Thumbnail/Thumbnail.tsx
+++ b/src/components/Thumbnail/Thumbnail.tsx
@@ -1,0 +1,23 @@
+import { ThumbnailProps } from '@/types/thumbnail.type';
+import Image from 'next/image';
+
+function Thumbnail(props: ThumbnailProps) {
+  const {
+    width = '14.6875rem',
+    height = '11.25rem',
+    borderRadius = '1rem',
+    objectFit = 'cover',
+    src,
+    alt,
+  } = props;
+
+  return (
+    <Image
+      style={{ width, height, borderRadius, objectFit }}
+      src={src}
+      alt={alt}
+    />
+  );
+}
+
+export default Thumbnail;

--- a/src/components/Thumbnail/index.tsx
+++ b/src/components/Thumbnail/index.tsx
@@ -1,0 +1,3 @@
+import Thumbnail from './Thumbnail';
+
+export default Thumbnail;

--- a/src/components/TitleDesc/TitleDesc.styled.ts
+++ b/src/components/TitleDesc/TitleDesc.styled.ts
@@ -7,7 +7,7 @@ export const TitleDescContainer = styled.div<{ $sort: SortMethod }>`
 
   h2 {
     font-size: 2rem;
-    margin-bottom: 1.75rem;
+    margin-bottom: 1.25rem;
   }
 
   p {

--- a/src/types/badge.type.ts
+++ b/src/types/badge.type.ts
@@ -1,0 +1,5 @@
+export interface BadgeProps {
+  backgroundColor?: string;
+  color?: string;
+  text: string;
+}

--- a/src/types/info/officeInfo.type.ts
+++ b/src/types/info/officeInfo.type.ts
@@ -1,0 +1,7 @@
+export interface OfficeInfoProps {
+  placeName: string;
+  officeType?: string;
+  dayAndNight?: string;
+  price?: string;
+  priceUnit?: string;
+}

--- a/src/types/info/officeInfo.type.ts
+++ b/src/types/info/officeInfo.type.ts
@@ -2,6 +2,6 @@ export interface OfficeInfoProps {
   placeName: string;
   officeType?: string;
   dayAndNight?: string;
-  price?: string;
+  price?: number;
   priceUnit?: string;
 }

--- a/src/types/priceUnit.type.ts
+++ b/src/types/priceUnit.type.ts
@@ -1,0 +1,4 @@
+export interface PriceUnitProps {
+  price: string;
+  unit: string;
+}

--- a/src/types/priceUnit.type.ts
+++ b/src/types/priceUnit.type.ts
@@ -1,4 +1,4 @@
 export interface PriceUnitProps {
-  price: string;
+  price: number;
   unit: string;
 }

--- a/src/types/statefulTitleDesc.type.ts
+++ b/src/types/statefulTitleDesc.type.ts
@@ -1,0 +1,7 @@
+export type TextState = 'active' | 'inactive';
+
+export interface StatefulTitleDescProps {
+  title: string;
+  desc: string;
+  state: TextState;
+}

--- a/src/types/thumbnail.type.ts
+++ b/src/types/thumbnail.type.ts
@@ -1,0 +1,17 @@
+import { StaticImageData } from 'next/image';
+
+export type ObjectFitType =
+  | 'fill'
+  | 'contain'
+  | 'cover'
+  | 'none'
+  | 'scale-down';
+
+export interface ThumbnailProps {
+  width?: string;
+  height?: string;
+  borderRadius?: string;
+  objectFit?: ObjectFitType;
+  src: string | StaticImageData;
+  alt: string;
+}


### PR DESCRIPTION
## 🍋 PR 요약
- 메인 페이지 작업 중간 반영

## ✨ PR 상세 내용
- 메인 페이지 3번째, 4번째 페이지 작업
- 5번째 섹션에서 쓰일 `StatefulTitleDesc` 작업
- 마지막 섹션에서 쓰일 `Thumbnail`, `Badge`, `PriceUnit`, `OfficeInfo` 컴포넌트 작업

## 🚨 주의 사항
- **page.tsx 안에 스타일 컴포넌트 줄줄이 생기는 거 싫어서 CSS module 사용해 봤습니다... 전의 방식으로 하면 page 컴포넌트인데 코드 너무 길어지는 것 같아서 ㅠㅠ**
- 컴포넌트 잘게 쪼개고 싶어서 잘게 쪼갰습니다. storybook 있으니까 참고하면서 재사용 가능한 거 갖다 써도 좋을 것 같아요!!
- 5번째 섹션 스크롤 파트 어려워서 일단 건너뛰었습니다...
- 마지막 섹션은 컴포넌트 작업은 거의 다 해두었고 배치는 안 했습니다! 아직 스크롤 부분이 어떻게 될지 모르겠어서...

## 📸 스크린샷

![image](https://github.com/user-attachments/assets/98bba264-805b-462e-8fc2-3fc6957ab844)

StatefulTitleDesc (활성화/비활성화 여부에 따라 다르게 보이는 TitleDesc)

![image](https://github.com/user-attachments/assets/23f2049e-1c45-4752-8597-1ff2399e5ccc)

Thumbnail (썸네일 이미지 여기저기서 쓰려고 따로 뺌)

![image](https://github.com/user-attachments/assets/732b549e-6788-4570-a184-de440895214b)

OfficeInfo (오피스 타입이랑 24시간 운영 여부 나타낸 게 `Badge` 컴포넌트고, 가격/단위로 나타낸 게 `PriceUnit` 컴포넌트)

![image](https://github.com/user-attachments/assets/091d4f49-dfda-4ff9-8295-306ee997c092)

메인 페이지 4번째 섹션

![image](https://github.com/user-attachments/assets/0510b87d-05d1-4f93-9bbc-2a19862af149)

메인 페이지 5번째 섹션


## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [ ] 변경 사항에 대한 테스트 진행했나요?
- [x] `npm run format:fix` 실행했나요?
