### PR TITLE
OFZ-7 feat: 지역 메뉴 개발

### DIFF
--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -133,3 +133,23 @@
   bottom: 6.13rem;
   right: 11.44rem;
 }
+
+.fifth-main {
+  width: 100%;
+  height: 100vh;
+  position: relative;
+}
+
+.sixth-main {
+  width: 100%;
+  height: 100vh;
+  position: relative;
+  padding: 6.75rem 11.4375rem 11.125rem 11.4375rem;
+}
+
+.sixth-btn-list {
+  display: flex;
+  list-style: none;
+  gap: 1rem;
+  margin-top: 1.875rem;
+}

--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -147,9 +147,15 @@
   padding: 6.75rem 11.4375rem 11.125rem 11.4375rem;
 }
 
+.sixth-select-bar {
+  display: flex;
+  justify-content: space-between;
+  width: max-content;
+  margin-top: 1.875rem;
+}
+
 .sixth-btn-list {
   display: flex;
   list-style: none;
   gap: 1rem;
-  margin-top: 1.875rem;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,8 +15,19 @@ import BasicButton from '@/components/Button/BasicButton';
 import styles from './page.module.css';
 import { regionArr } from '@/constants/office';
 import SelectButton from '@/components/Button/SelectButton';
+import useRegionStore, { Region } from '@/store/useRegionStore';
 
 export default function MainPage() {
+  const { selectedRegion, setSelectedRegion } = useRegionStore((state) => ({
+    selectedRegion: state.selectedRegion,
+    setSelectedRegion: state.setSelectedRegion,
+  }));
+
+  const clickHandler = (e: React.MouseEvent<HTMLElement>) => {
+    const text = e.currentTarget.innerText as Region;
+    setSelectedRegion(text);
+  };
+
   return (
     <>
       <Header />
@@ -114,9 +125,10 @@ export default function MainPage() {
             {regionArr.map((item) => (
               <li key={item.id} className={styles['sixth-btn-li']}>
                 <SelectButton
-                  selected={false}
+                  selected={selectedRegion === item.region}
                   btnText={item.region}
                   btnHeight="2.5rem"
+                  clickHandler={clickHandler}
                 />
               </li>
             ))}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,18 +1,20 @@
 'use client';
 
 import Image from 'next/image';
-import { Fragment } from 'react';
 import Header from '@/components/Header';
 import thumbnail from '../../public/thumbnail.png';
 import TitleDesc from '@/components/TitleDesc';
 import {
   DASHBOARD_MAIN,
+  RECOMMEND_MAIN,
   RETROSPECT_MAIN,
   TODO_MAIN,
   TOP_MAIN,
 } from '@/constants/main';
 import BasicButton from '@/components/Button/BasicButton';
 import styles from './page.module.css';
+import { regionArr } from '@/constants/office';
+import SelectButton from '@/components/Button/SelectButton';
 
 export default function MainPage() {
   return (
@@ -100,6 +102,25 @@ export default function MainPage() {
               sort="left"
             />
           </section>
+        </section>
+        <section className={styles['fifth-main']}></section>
+        <section className={styles['sixth-main']}>
+          <TitleDesc
+            title={RECOMMEND_MAIN.title}
+            desc={RECOMMEND_MAIN.desc}
+            sort="left"
+          />
+          <ul className={styles['sixth-btn-list']}>
+            {regionArr.map((item) => (
+              <li key={item.id} className={styles['sixth-btn-li']}>
+                <SelectButton
+                  selected={false}
+                  btnText={item.region}
+                  btnHeight="2.5rem"
+                />
+              </li>
+            ))}
+          </ul>
         </section>
       </main>
     </>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -49,6 +49,7 @@ export default function MainPage() {
               btnColor="var(--blue-main)"
               textColor="var(--white-main)"
               hoverColor="var(--blue-dark)"
+              padding="1rem 2rem"
               clickHandler={() => {}}
             />
           </section>
@@ -121,18 +122,29 @@ export default function MainPage() {
             desc={RECOMMEND_MAIN.desc}
             sort="left"
           />
-          <ul className={styles['sixth-btn-list']}>
-            {regionArr.map((item) => (
-              <li key={item.id} className={styles['sixth-btn-li']}>
-                <SelectButton
-                  selected={selectedRegion === item.region}
-                  btnText={item.region}
-                  btnHeight="2.5rem"
-                  clickHandler={clickHandler}
-                />
-              </li>
-            ))}
-          </ul>
+          <div className={styles['sixth-select-bar']}>
+            <ul className={styles['sixth-btn-list']}>
+              {regionArr.map((item) => (
+                <li key={item.id} className={styles['sixth-btn-li']}>
+                  <SelectButton
+                    selected={selectedRegion === item.region}
+                    btnText={item.region}
+                    btnHeight="2.5rem"
+                    clickHandler={clickHandler}
+                  />
+                </li>
+              ))}
+            </ul>
+            <BasicButton
+              btnText={RECOMMEND_MAIN.viewAllBtnText}
+              btnType="empty"
+              btnHeight="2.75rem"
+              textColor="var(--blue-main)"
+              hoverColor="var(--blue-greyish)"
+              padding="0.5rem 1rem"
+              clickHandler={() => {}}
+            />
+          </div>
         </section>
       </main>
     </>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -115,7 +115,7 @@ export default function MainPage() {
             />
           </section>
         </section>
-        <section className={styles['fifth-main']}></section>
+        <section className={styles['fifth-main']} />
         <section className={styles['sixth-main']}>
           <TitleDesc
             title={RECOMMEND_MAIN.title}

--- a/src/components/Button/BasicButton/BasicButton.styled.ts
+++ b/src/components/Button/BasicButton/BasicButton.styled.ts
@@ -7,16 +7,20 @@ export const StyledBtn = styled.button<{
   $btnColor?: string;
   $textColor: string;
   $hoverColor?: string;
+  $padding: string;
 }>`
   background-color: ${(props) =>
     props.$btnType === 'empty' ? 'transparent' : props.$btnColor};
   border: ${(props) =>
-    props.$btnType === 'full' ? 'none' : `1px solid ${props.$textColor}`};
+    props.$btnType === 'empty' ? 'none' : `1px solid ${props.$textColor}`};
   color: ${(props) => props.$textColor};
   border-radius: 3rem;
   height: ${(props) => props.$btnHeight};
-  padding: 1rem 2rem;
-  font-size: 1.125rem;
+  padding: ${(props) => props.$padding};
+  font-size: 1.25rem;
+  font-weight: 600;
+  font-family: Pretendard;
+  line-height: 1.75rem;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -25,6 +29,6 @@ export const StyledBtn = styled.button<{
   :hover {
     background-color: ${(props) =>
       props.$hoverColor || props.$btnColor || 'initial'};
-    transition: 0.5s;
+    transition: background-color 0.5s ease-out;
   }
 `;

--- a/src/components/Button/BasicButton/BasicButton.tsx
+++ b/src/components/Button/BasicButton/BasicButton.tsx
@@ -9,6 +9,7 @@ function BasicButton(props: ButtonProps) {
     btnColor,
     textColor,
     hoverColor,
+    padding,
     clickHandler,
   } = props;
 
@@ -20,6 +21,7 @@ function BasicButton(props: ButtonProps) {
       $btnColor={btnColor}
       $textColor={textColor}
       $hoverColor={hoverColor}
+      $padding={padding}
     >
       {btnText}
     </StyledBtn>

--- a/src/components/Button/SelectButton/SelectButton.tsx
+++ b/src/components/Button/SelectButton/SelectButton.tsx
@@ -2,10 +2,14 @@ import { SelectButtonProps } from '@/types/selectButton.type';
 import { StyledBtn } from './SelectButton.styled';
 
 function SelectButton(props: SelectButtonProps) {
-  const { selected, btnHeight, btnText } = props;
+  const { selected, btnHeight, btnText, clickHandler } = props;
 
   return (
-    <StyledBtn $selected={selected} $btnHeight={btnHeight}>
+    <StyledBtn
+      $selected={selected}
+      $btnHeight={btnHeight}
+      onClick={clickHandler}
+    >
       {btnText}
     </StyledBtn>
   );

--- a/src/components/OfficeAccordion/OfficeAccordion.tsx
+++ b/src/components/OfficeAccordion/OfficeAccordion.tsx
@@ -52,10 +52,10 @@ function OfficeAccordion(props: OfficeAccordionProps) {
       </OfficeAccordionToggle>
       <OfficeAccordionContent $isOpen={isOpen}>
         <TitleContent title={OFFICE_INFO_TITLE.facility}>
-          {regionArr.map((item, idx) => (
+          {regionArr.map((item) => (
             <Badge
-              key={idx}
-              text={item}
+              key={item.id}
+              text={item.region}
               height="1.875rem"
               fontSize="1rem"
               padding="0.25rem 0.75rem"

--- a/src/constants/main.ts
+++ b/src/constants/main.ts
@@ -46,7 +46,6 @@ export const RECAP_MAIN = {
 export const RECOMMEND_MAIN = {
   title: '그럼, 어디로 떠나볼까요?',
   desc: '워케이션 기간동안 생산성을 높여 줄 공유 오피스예요',
-  regionArr: ['서울', '강원', '제주', '부산', '경기', '기타'],
   notLoginDesc: '로그인하고 더 많은 공유오피스 보기 >',
   viewAllBtnText: '전체보기 >',
 };

--- a/src/constants/office.ts
+++ b/src/constants/office.ts
@@ -1,13 +1,13 @@
 export const regionArr = [
-  '서울',
-  '부산',
-  '인천',
-  '경기',
-  '대구',
-  '대전',
-  '충청',
-  '경상',
-  '기타',
+  { id: 1, region: '서울' },
+  { id: 2, region: '부산' },
+  { id: 3, region: '인천' },
+  { id: 4, region: '경기' },
+  { id: 5, region: '대구' },
+  { id: 6, region: '대전' },
+  { id: 7, region: '충청' },
+  { id: 8, region: '경상' },
+  { id: 9, region: '기타' },
 ];
 
 export const OFFICE_INFO_TITLE = {

--- a/src/constants/office.ts
+++ b/src/constants/office.ts
@@ -1,13 +1,9 @@
 export const regionArr = [
-  { id: 1, region: '서울' },
-  { id: 2, region: '부산' },
-  { id: 3, region: '인천' },
-  { id: 4, region: '경기' },
-  { id: 5, region: '대구' },
-  { id: 6, region: '대전' },
-  { id: 7, region: '충청' },
-  { id: 8, region: '경상' },
-  { id: 9, region: '기타' },
+  { id: 1, region: '수도권' },
+  { id: 2, region: '경상권' },
+  { id: 3, region: '제주권' },
+  { id: 4, region: '충청권' },
+  { id: 5, region: '전라권' },
 ];
 
 export const OFFICE_INFO_TITLE = {

--- a/src/store/useRegionStore.ts
+++ b/src/store/useRegionStore.ts
@@ -1,7 +1,7 @@
 import { regionArr } from '@/constants/office';
 import { create } from 'zustand';
 
-type Region = (typeof regionArr)[number]['region'];
+export type Region = (typeof regionArr)[number]['region'];
 
 interface RegionStoreType {
   selectedRegion: Region;

--- a/src/store/useRegionStore.ts
+++ b/src/store/useRegionStore.ts
@@ -1,0 +1,18 @@
+import { regionArr } from '@/constants/office';
+import { create } from 'zustand';
+
+type Region = (typeof regionArr)[number]['region'];
+
+interface RegionStoreType {
+  selectedRegion: Region;
+  setSelectedRegion: (region: Region) => void;
+}
+
+const useRegionStore = create<RegionStoreType>((set) => ({
+  selectedRegion: regionArr[0].region,
+  setSelectedRegion: (region) => {
+    set(() => ({ selectedRegion: region }));
+  },
+}));
+
+export default useRegionStore;

--- a/src/store/useRegionStore.ts
+++ b/src/store/useRegionStore.ts
@@ -1,5 +1,5 @@
-import { regionArr } from '@/constants/office';
 import { create } from 'zustand';
+import { regionArr } from '@/constants/office';
 
 export type Region = (typeof regionArr)[number]['region'];
 

--- a/src/types/button.type.ts
+++ b/src/types/button.type.ts
@@ -5,6 +5,7 @@ export interface BaseProps {
   textColor: string;
   btnText: string;
   btnHeight: string;
+  padding: string;
   hoverColor?: string;
   clickHandler: () => void;
 }

--- a/src/types/selectButton.type.ts
+++ b/src/types/selectButton.type.ts
@@ -2,4 +2,5 @@ export interface SelectButtonProps {
   selected: boolean;
   btnHeight: string;
   btnText: string;
+  clickHandler: (() => void) | ((e: React.MouseEvent<HTMLElement>) => void);
 }


### PR DESCRIPTION
## 🍋 PR 요약
지역 메뉴 개발

## ✨ PR 상세 내용
- 지역 메뉴 store 생성해서 상태로 저장하게 구현
- 메인 페이지 맨 아래 추천 섹션 기본 자리잡기
- 지역 배열 이름 '서울', '부산'... 이런 식이었는데 저번 회의에서 '수도권', '경상권' 이런 식으로 변경되어서 반영했습니다

## 🚨 주의 사항
**react-query 슬슬 도입하려는데 브랜치 따로 파서 하는 게 좋을 것 같아서 일단 작업 사항 올립니다**

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/0482af6c-9408-42f6-8029-cab8ab2d1b65)


## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [ ] 변경 사항에 대한 테스트 진행했나요?
- [x] `npm run format:fix` 실행했나요?
