### PR TITLE
OFZ-23 feat: react-query 세팅 추가

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 export const instance = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_SERVER_URL,
+  baseURL: `${process.env.NEXT_PUBLIC_SERVER_URL}/api`,
   timeout: 5000,
   headers: {
     'Content-type': 'application/json',

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,6 +1,23 @@
+import useUserStore from '@/store/useUserStore';
 import axios from 'axios';
 
 export const instance = axios.create({
-  baseURL: 'https://example.com', // 추후 서버 주소 나오면 환경변수로 변경
+  baseURL: process.env.NEXT_PUBLIC_SERVER_URL,
   timeout: 5000,
+  headers: {
+    'Content-type': 'application/json',
+  },
+  withCredentials: true,
+});
+
+instance.interceptors.request.use((config) => {
+  const { accessToken } = useUserStore((state) => ({
+    accessToken: state.accessToken,
+  }));
+
+  if (accessToken) {
+    config.headers['Authorization'] = `Bearer ${accessToken}`;
+  }
+
+  return config;
 });

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -9,6 +9,4 @@ export const instance = axios.create({
   withCredentials: true,
 });
 
-instance.interceptors.request.use((config) => {
-  return config;
-});
+instance.interceptors.request.use((config) => config);

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,4 +1,3 @@
-import useUserStore from '@/store/useUserStore';
 import axios from 'axios';
 
 export const instance = axios.create({
@@ -11,13 +10,5 @@ export const instance = axios.create({
 });
 
 instance.interceptors.request.use((config) => {
-  const { accessToken } = useUserStore((state) => ({
-    accessToken: state.accessToken,
-  }));
-
-  if (accessToken) {
-    config.headers['Authorization'] = `Bearer ${accessToken}`;
-  }
-
   return config;
 });

--- a/src/api/office/getOffice.ts
+++ b/src/api/office/getOffice.ts
@@ -1,0 +1,32 @@
+import { instance } from '../axios';
+
+export interface GetRegionOfficeParams {
+  region: string; // available한 값만 들어오게 수정 예정
+  size: number;
+}
+
+export interface OfficeInfoType {
+  officeId: number;
+  name: string;
+  facilities: {
+    twentyFourHoursOperation: boolean;
+    openAllYear: boolean;
+  };
+  address: string;
+  price: number;
+  priceType: string;
+}
+
+export interface GetOfficeResponse {
+  recOffices: Array<OfficeInfoType>;
+}
+
+export interface GetAllOfficeResponse extends GetOfficeResponse {
+  totalPage: number;
+}
+
+export const getRecRegionOffice = (params: GetRegionOfficeParams) => {
+  const { region = '서울', size = 4 } = params;
+
+  return instance.get<GetOfficeResponse>(`/api/office/rec/${region}/${size}`);
+};

--- a/src/api/office/getOffice.ts
+++ b/src/api/office/getOffice.ts
@@ -1,6 +1,6 @@
 import { instance } from '../axios';
 
-export interface GetRegionOfficeParams {
+export interface GetRecRegionOfficeParams {
   region: string; // available한 값만 들어오게 수정 예정
   size: number;
 }
@@ -25,7 +25,7 @@ export interface GetAllOfficeResponse extends GetOfficeResponse {
   totalPage: number;
 }
 
-export const getRecRegionOffice = (params: GetRegionOfficeParams) => {
+export const getRecRegionOffice = (params: GetRecRegionOfficeParams) => {
   const { region = '서울', size = 4 } = params;
 
   return instance.get<GetOfficeResponse>(`/api/office/rec/${region}/${size}`);

--- a/src/api/office/getOffice.ts
+++ b/src/api/office/getOffice.ts
@@ -28,5 +28,5 @@ export interface GetAllOfficeResponse extends GetOfficeResponse {
 export const getRecRegionOffice = (params: GetRecRegionOfficeParams) => {
   const { region = '서울', size = 4 } = params;
 
-  return instance.get<GetOfficeResponse>(`/api/office/rec/${region}/${size}`);
+  return instance.get<GetOfficeResponse>(`/office/rec/${region}/${size}`);
 };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next';
 import './globals.css';
+import { QueryClientProvider } from '@tanstack/react-query';
+import queryClient from '@/services/queryClient';
 
 export const metadata: Metadata = {
   title: 'OFFIZZ',
@@ -12,8 +14,10 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="ko">
-      <body>{children}</body>
-    </html>
+    <QueryClientProvider client={queryClient}>
+      <html lang="ko">
+        <body>{children}</body>
+      </html>
+    </QueryClientProvider>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,12 +16,23 @@ import styles from './page.module.css';
 import { regionArr } from '@/constants/office';
 import SelectButton from '@/components/Button/SelectButton';
 import useRegionStore, { Region } from '@/store/useRegionStore';
+import { useRecRegionOfficeQuery } from '@/services/office/useRecRegionOfficeQuery';
+import { useEffect } from 'react';
 
 export default function MainPage() {
   const { selectedRegion, setSelectedRegion } = useRegionStore((state) => ({
     selectedRegion: state.selectedRegion,
     setSelectedRegion: state.setSelectedRegion,
   }));
+
+  const { data, status } = useRecRegionOfficeQuery({
+    region: '서울',
+    size: 4,
+  });
+
+  useEffect(() => {
+    console.log(data);
+  }, [status]);
 
   const clickHandler = (e: React.MouseEvent<HTMLElement>) => {
     const text = e.currentTarget.innerText as Region;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Image from 'next/image';
+import { useEffect } from 'react';
 import Header from '@/components/Header';
 import thumbnail from '../../public/thumbnail.png';
 import TitleDesc from '@/components/TitleDesc';
@@ -17,7 +18,6 @@ import { regionArr } from '@/constants/office';
 import SelectButton from '@/components/Button/SelectButton';
 import useRegionStore, { Region } from '@/store/useRegionStore';
 import { useRecRegionOfficeQuery } from '@/services/office/useRecRegionOfficeQuery';
-import { useEffect } from 'react';
 
 export default function MainPage() {
   const { selectedRegion, setSelectedRegion } = useRegionStore((state) => ({

--- a/src/services/office/useRecRegionOfficeQuery.ts
+++ b/src/services/office/useRecRegionOfficeQuery.ts
@@ -1,8 +1,8 @@
+import { useQuery } from '@tanstack/react-query';
 import {
   GetRecRegionOfficeParams,
   getRecRegionOffice,
 } from '@/api/office/getOffice';
-import { useQuery } from '@tanstack/react-query';
 
 export const useRecRegionOfficeQuery = (params: GetRecRegionOfficeParams) =>
   useQuery({

--- a/src/services/office/useRecRegionOfficeQuery.ts
+++ b/src/services/office/useRecRegionOfficeQuery.ts
@@ -1,0 +1,18 @@
+import {
+  GetRecRegionOfficeParams,
+  getRecRegionOffice,
+} from '@/api/office/getOffice';
+import { useQuery } from '@tanstack/react-query';
+
+export const useRecRegionOfficeQuery = (params: GetRecRegionOfficeParams) =>
+  useQuery({
+    queryKey: ['office', params],
+    queryFn: async () => {
+      const response = await getRecRegionOffice(params);
+      const { data } = response;
+      const { recOffices } = data;
+
+      return recOffices;
+    },
+    staleTime: 1000 * 20,
+  });

--- a/src/services/queryClient.ts
+++ b/src/services/queryClient.ts
@@ -1,0 +1,12 @@
+'use client';
+import { QueryClient } from '@tanstack/react-query';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 1000 * 20,
+    },
+  },
+});
+
+export default queryClient;

--- a/src/services/queryClient.ts
+++ b/src/services/queryClient.ts
@@ -1,4 +1,5 @@
 'use client';
+
 import { QueryClient } from '@tanstack/react-query';
 
 const queryClient = new QueryClient({

--- a/src/store/useUserStore.ts
+++ b/src/store/useUserStore.ts
@@ -1,0 +1,15 @@
+import { create } from 'zustand';
+
+interface UserStoreType {
+  accessToken: string;
+  setAccessToken: (token: string) => void;
+}
+
+const useUserStore = create<UserStoreType>((set) => ({
+  accessToken: '',
+  setAccessToken: (token) => {
+    set(() => ({ accessToken: token }));
+  },
+}));
+
+export default useUserStore;


### PR DESCRIPTION
## 🍋 PR 요약
react-query 세팅 추가

## ✨ PR 상세 내용
- axios instance 세팅
- QueryClient, QueryProvider 세팅
- `api` : axios 세팅이나 react-query의 query function 모아놓는 폴더입니다
- `services` : `api` 폴더에 만들어놓은 query function을 가지고 useQuery 커스텀하는 폴더입니다. 사용할 때는 여기에 있는 useQuery들을 사용하게 됩니다

## 🚨 주의 사항
- **환경변수 바뀌었습니다** (노션 참고)
- 스웨거 보니까 모든 api 엔드포인트가 `/api`로 시작하더라구요. 그래서 axios instance의 baseUrl 설정할 때, `서버주소/api` 이렇게 설정해놔서 호출할 때 그 뒤의 경로부터 써야 합니다!
- app/page.tsx에 있는 테스트 코드는 일부러 안 지웠습니다! 사용처에서 어떻게 사용하는 건지 보시면 좋을 것 같습니다 (자세한 건 react-query 공식문서에서 useQuery 리턴값들 보면 좋을 것 같습니다)
- 이번에야말로 access token 그냥 상태관리 도구에 저장하는 걸로 해보려고 했는데 zustand가 `useUserStore` 이런 식으로 hook처럼 쓰이다 보니 invalid hook error가 나서 일단 제거했습니다 ㅠㅠ interceptor에 나중에 세팅해보겠습니다
- region은 '수도권', '경상권'... 이런 값들만 들어갈 수 있는데 아직 업데이트가 안 되었고 '서울', '부산'...이 들어가게 되어 있어서 저도 타입을 아직 지정 안 했습니다. 백쪽에서 api 수정 마치면 타입 지정할 것 같습니다.

## 📸 스크린샷
화면이 달라진 건 없어서 첨부하지 않겠습니다!

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [ ] 변경 사항에 대한 테스트 진행했나요?
- [x] `npm run format:fix` 실행했나요?
