### PR TITLE
OFZ-45 fix: 헤더 및 로그인 로직 작업

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "next": "14.1.1",
         "react": "^18",
         "react-calendar": "^5.0.0",
+        "react-cookie": "^7.2.0",
         "react-dom": "^18",
         "react-kakao-maps-sdk": "^1.1.27",
         "styled-components": "6.1.11",
@@ -6248,6 +6249,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "license": "MIT"
+    },
     "node_modules/@types/cross-spawn": {
       "version": "6.0.6",
       "resolved": "https://registry.npmjs.org/@types/cross-spawn/-/cross-spawn-6.0.6.tgz",
@@ -9397,7 +9404,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -17194,6 +17200,20 @@
         "react": "^16.3.0 || ^17.0.1 || ^18.0.0"
       }
     },
+    "node_modules/react-cookie": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-7.2.0.tgz",
+      "integrity": "sha512-mqhPERUyfOljq5yJ4woDFI33bjEtigsl8JDJdPPeNhr0eSVZmBc/2Vdf8mFxOUktQxhxTR1T+uF0/FRTZyBEgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.3.5",
+        "hoist-non-react-statics": "^3.3.2",
+        "universal-cookie": "^7.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0"
+      }
+    },
     "node_modules/react-docgen": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-7.0.3.tgz",
@@ -19978,6 +19998,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/universal-cookie": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-7.2.0.tgz",
+      "integrity": "sha512-PvcyflJAYACJKr28HABxkGemML5vafHmiL4ICe3e+BEKXRMt0GaFLZhAwgv637kFFnnfiSJ8e6jknrKkMrU+PQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookie": "^0.6.0",
+        "cookie": "^0.6.0"
       }
     },
     "node_modules/universalify": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "next": "14.1.1",
     "react": "^18",
     "react-calendar": "^5.0.0",
+    "react-cookie": "7.2.0",
     "react-dom": "^18",
     "react-kakao-maps-sdk": "^1.1.27",
     "styled-components": "6.1.11",

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import useUserStore from '@/store/useUserStore';
+// import useUserStore from '@/store/useUserStore';
 
 export const instance = axios.create({
   baseURL: `${process.env.NEXT_PUBLIC_SERVER_URL}/api`,
@@ -10,12 +10,12 @@ export const instance = axios.create({
   withCredentials: true,
 });
 
-instance.interceptors.request.use((config) => {
-  const { accessToken } = useUserStore.getState();
+// instance.interceptors.request.use((config) => {
+//   const { accessToken } = useUserStore.getState();
 
-  if (accessToken) {
-    config.headers.set('Authorization', accessToken);
-  }
+//   if (accessToken) {
+//     config.headers.set('Authorization', accessToken);
+//   }
 
-  return config;
-});
+//   return config;
+// });

--- a/src/app/information/components/Recommend/Recommend.tsx
+++ b/src/app/information/components/Recommend/Recommend.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Link from 'next/link';
-import { RecommendBox } from './Recommend.styled'
+import { RecommendBox } from './Recommend.styled';
 
 function Recommend() {
   return (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import Script from 'next/script';
 import queryClient from '@/services/queryClient';
 import StyledComponentsRegistry from '@/lib/registry';
+import CookieProviderWrapper from '@/lib/CookieProviderWrapper';
 
 export const metadata: Metadata = {
   title: 'OFFIZZ',
@@ -17,17 +18,19 @@ export default function RootLayout({
 }>) {
   return (
     <QueryClientProvider client={queryClient}>
-      <html lang="ko">
-        <body>
-          <StyledComponentsRegistry>
-            <Script
-              src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_JS}&libraries=services,clusterer&autoload=false`}
-              strategy="beforeInteractive"
-            />
-            {children}
-          </StyledComponentsRegistry>
-        </body>
-      </html>
+      <CookieProviderWrapper>
+        <html lang="ko">
+          <body>
+            <StyledComponentsRegistry>
+              <Script
+                src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_JS}&libraries=services,clusterer&autoload=false`}
+                strategy="beforeInteractive"
+              />
+              {children}
+            </StyledComponentsRegistry>
+          </body>
+        </html>
+      </CookieProviderWrapper>
     </QueryClientProvider>
   );
 }

--- a/src/app/login/oauth2/code/kakao/page.tsx
+++ b/src/app/login/oauth2/code/kakao/page.tsx
@@ -1,23 +1,31 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { instance } from '@/api/axios';
+import useAuth from '@/hook/useAuth';
 
 function KakaoLoginPage() {
   const router = useRouter();
-  const code = useRef('');
+  const { setAccessToken, setRefreshToken } = useAuth();
 
   useEffect(() => {
     const urlParams = new URLSearchParams(window.location.search);
-    code.current = urlParams.get('code') || '';
+    const code = urlParams.get('code') || '';
 
     if (code) {
       instance
         .post('/auth/login/KAKAO', { code })
         .then((res) => {
           if (res.status === 200) {
-            // token 세팅 코드 추가
+            setAccessToken({
+              token: res.data.accessToken,
+              expire: res.data.accessExpiration,
+            });
+            setRefreshToken({
+              token: res.data.refreshToken,
+              expire: res.data.refreshExpiration,
+            });
           }
           router.replace('/');
         })
@@ -26,7 +34,7 @@ function KakaoLoginPage() {
           router.replace('/');
         });
     }
-  }, [code, router]);
+  }, []);
 }
 
 export default KakaoLoginPage;

--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -150,7 +150,7 @@
 .sixth-select-bar {
   display: flex;
   justify-content: space-between;
-  width: max-content;
+  width: 62.5rem;
   margin-top: 1.875rem;
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,7 +20,7 @@ import useRegionStore, { Region } from '@/store/useRegionStore';
 
 export default function MainPage() {
   // const { accessToken, setAccessToken } = useUserStore.getState();
-  const { selectedRegion, setSelectedRegion } = useRegionStore.getState();
+  const { selectedRegion, setSelectedRegion } = useRegionStore();
 
   const clickHandler = (e: React.MouseEvent<HTMLElement>) => {
     const text = e.currentTarget.innerText as Region;

--- a/src/components/Header/Header.styled.ts
+++ b/src/components/Header/Header.styled.ts
@@ -6,34 +6,48 @@ export const HeaderContainer = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0 2.5rem;
+  padding: 0 11.4375rem;
   backdrop-filter: blur(14px);
   position: fixed;
   top: 0;
   z-index: 1;
+  font-family: Figtree;
 
-  h1 {
-    cursor: pointer;
+  #logo-img {
+    width: 3.125rem;
+    height: 1rem;
   }
 
   button {
-    cursor: pointer;
     border: none;
     background-color: transparent;
-    font-size: 1.5rem;
+    width: fit-content;
+    height: 2.25rem;
+    padding: 0 1rem;
+    font-size: 1rem;
+    display: flex;
+    align-items: center;
+    cursor: pointer;
   }
 `;
 
 export const HeaderMenuContainer = styled.ul`
-  width: 60%;
-  height: 1.82rem;
+  width: 13.4375rem;
+  height: 2.25rem;
   display: flex;
   justify-content: space-between;
   list-style-type: none;
+  position: absolute;
+  left: 17.8125rem;
 `;
 
 export const HeaderMenu = styled.li<{ $isSelected: boolean }>`
-  font-size: 1.5rem;
+  width: fit-content;
+  height: 2.25rem;
+  padding: 0 1rem;
+  font-size: 1rem;
+  display: flex;
+  align-items: center;
   cursor: pointer;
   color: ${(props) =>
     props.$isSelected ? 'var(--black-main)' : 'var(--inactive-gray)'};

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -7,6 +7,8 @@ import {
 } from './Header.styled';
 import useHeaderMenuStore from '@/store/useMenuStore';
 import { HeaderTextUnion } from '@/types/header.type';
+import Image from 'next/image';
+import logo from 'public/offizz-logo.png';
 
 function Header() {
   const router = useRouter();
@@ -28,7 +30,14 @@ function Header() {
 
   return (
     <HeaderContainer>
-      <h1>{HEADER_TEXT.appName}</h1>
+      <Image
+        src={logo}
+        alt="오피츠 로고 이미지"
+        id="logo-img"
+        onClick={() => {
+          router.push('/');
+        }}
+      />
       <HeaderMenuContainer>
         <HeaderMenu
           $isSelected={selectedMenu === HEADER_TEXT.home}

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,6 +1,9 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
+import Image from 'next/image';
+import logo from 'public/offizz-logo.png';
+import { useEffect, useState } from 'react';
 import { HEADER_TEXT } from '@/constants/header';
 import {
   HeaderContainer,
@@ -9,10 +12,7 @@ import {
 } from './Header.styled';
 import useHeaderMenuStore from '@/store/useMenuStore';
 import { HeaderTextUnion } from '@/types/header.type';
-import Image from 'next/image';
-import logo from 'public/offizz-logo.png';
 import useAuth from '@/hook/useAuth';
-import { useEffect, useState } from 'react';
 
 function Header() {
   const { getAccessToken } = useAuth();

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useRouter } from 'next/navigation';
 import { HEADER_TEXT } from '@/constants/header';
 import {
@@ -9,10 +11,20 @@ import useHeaderMenuStore from '@/store/useMenuStore';
 import { HeaderTextUnion } from '@/types/header.type';
 import Image from 'next/image';
 import logo from 'public/offizz-logo.png';
+import useAuth from '@/hook/useAuth';
+import { useEffect, useState } from 'react';
 
 function Header() {
+  const { getAccessToken } = useAuth();
+  const [token, setToken] = useState('');
   const router = useRouter();
   const { selectedMenu, setSelectedMenu } = useHeaderMenuStore();
+
+  useEffect(() => {
+    getAccessToken().then((accessTkn) => {
+      if (accessTkn) setToken(accessTkn);
+    });
+  }, []);
 
   const menuToRouteMap: Record<HeaderTextUnion, string> = {
     [HEADER_TEXT.home]: '/',
@@ -58,14 +70,16 @@ function Header() {
           {HEADER_TEXT.recap}
         </HeaderMenu>
       </HeaderMenuContainer>
-      <button
-        type="button"
-        onClick={() => {
-          router.push('/login');
-        }}
-      >
-        {HEADER_TEXT.login}
-      </button>
+      {!token && (
+        <button
+          type="button"
+          onClick={() => {
+            router.push('/login');
+          }}
+        >
+          {HEADER_TEXT.login}
+        </button>
+      )}
     </HeaderContainer>
   );
 }

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -10,11 +10,20 @@ import { HeaderTextUnion } from '@/types/header.type';
 
 function Header() {
   const router = useRouter();
-  const { selectedMenu, setSelectedMenu } = useHeaderMenuStore.getState();
+  const { selectedMenu, setSelectedMenu } = useHeaderMenuStore();
+
+  const menuToRouteMap: Record<HeaderTextUnion, string> = {
+    [HEADER_TEXT.home]: '/',
+    [HEADER_TEXT.recommendation]: '/recommend',
+    [HEADER_TEXT.recap]: '/recap',
+  };
 
   const handleClick = (e: React.MouseEvent<HTMLLIElement>) => {
     const text = e.currentTarget.innerText as HeaderTextUnion;
-    setSelectedMenu(text);
+    setSelectedMenu(text as HeaderTextUnion);
+
+    const route = menuToRouteMap[text];
+    if (route) router.push(route);
   };
 
   return (

--- a/src/constants/header.ts
+++ b/src/constants/header.ts
@@ -1,7 +1,7 @@
 export const HEADER_TEXT = {
   appName: 'OFFIZZ',
-  home: 'home',
-  recommendation: 'recommendation',
-  recap: 'recap',
+  home: '홈',
+  recommendation: '추천',
+  recap: '리캡',
   login: '로그인',
 } as const;

--- a/src/hook/useAuth.ts
+++ b/src/hook/useAuth.ts
@@ -1,0 +1,124 @@
+import { instance } from '@/api/axios';
+import { TokenProps } from '@/types/user.type';
+import { Cookies } from 'react-cookie';
+
+function useAuth() {
+  const cookies = new Cookies();
+  const refreshToken = cookies.get('refreshToken');
+
+  /** 초 단위 만료 시간 Date 객체로 반환 */
+  function calculateExpires(expires: number) {
+    const now = new Date();
+    const result = new Date(now.getTime() + expires * 1000);
+    return result;
+  }
+
+  function isExpired(expires: Date) {
+    const now = new Date();
+    if (now > expires) return true;
+    else return false;
+  }
+
+  function setAccessToken(props: TokenProps) {
+    const { token, expire } = props;
+    const expires = calculateExpires(expire);
+    localStorage.setItem('accessToken', token);
+    localStorage.setItem('accessExpire', expires.toString());
+  }
+
+  function setRefreshToken(props: TokenProps) {
+    const { token, expire } = props;
+    const expires = calculateExpires(expire);
+    cookies.set('refreshToken', token, {
+      path: '/',
+      expires,
+    });
+  }
+
+  function removeTokens() {
+    if (typeof window !== undefined) {
+      if (localStorage.hasOwnProperty('accessToken')) {
+        localStorage.removeItem('accessToken');
+      }
+
+      if (localStorage.hasOwnProperty('accessExpire')) {
+        localStorage.removeItem('accessExpire');
+      }
+
+      cookies.remove('refresh_token', {
+        path: '/',
+      });
+    }
+  }
+
+  async function reissueToken() {
+    try {
+      const res = await instance.post(`/auth/refresh`, null, {
+        headers: {
+          Authorization: `Bearer ${getRefreshToken()}`,
+        },
+      });
+
+      if (res.status === 200) {
+        setAccessToken({
+          token: res.data.accessToken,
+          expire: res.data.accessExpiration,
+        });
+        setRefreshToken({
+          token: res.data.refreshToken,
+          expire: res.data.refreshExpiration,
+        });
+        return;
+      } else {
+        removeTokens();
+        return;
+      }
+    } catch {}
+  }
+
+  function getRefreshToken() {
+    if (refreshToken) return refreshToken;
+
+    return '';
+  }
+
+  async function getAccessToken() {
+    if (
+      typeof window !== 'undefined' &&
+      localStorage.hasOwnProperty('accessToken') &&
+      localStorage.hasOwnProperty('accessExpire')
+    ) {
+      const accessTkn = localStorage.getItem('accessToken');
+      const accessExp = new Date(localStorage.getItem('accessExpire')!);
+
+      if (isExpired(accessExp)) {
+        if (getRefreshToken()) {
+          await reissueToken();
+          const accessTkn = localStorage.getItem('accessToken');
+          return accessTkn;
+        } else {
+          removeTokens();
+          return '';
+        }
+      }
+
+      if (!isExpired(accessExp)) return accessTkn;
+    } else {
+      if (getRefreshToken()) {
+        await reissueToken();
+        const accessTkn = localStorage.getItem('accessToken');
+        return accessTkn;
+      } else return '';
+    }
+  }
+
+  return {
+    setAccessToken,
+    setRefreshToken,
+    getAccessToken,
+    getRefreshToken,
+    removeTokens,
+  };
+}
+
+export default useAuth;

--- a/src/hook/useAuth.ts
+++ b/src/hook/useAuth.ts
@@ -1,6 +1,6 @@
+import { Cookies } from 'react-cookie';
 import { instance } from '@/api/axios';
 import { TokenProps } from '@/types/user.type';
-import { Cookies } from 'react-cookie';
 
 function useAuth() {
   const cookies = new Cookies();
@@ -16,7 +16,7 @@ function useAuth() {
   function isExpired(expires: Date) {
     const now = new Date();
     if (now > expires) return true;
-    else return false;
+    return false;
   }
 
   function setAccessToken(props: TokenProps) {
@@ -37,10 +37,12 @@ function useAuth() {
 
   function removeTokens() {
     if (typeof window !== undefined) {
+      // eslint-disable-next-line no-prototype-builtins
       if (localStorage.hasOwnProperty('accessToken')) {
         localStorage.removeItem('accessToken');
       }
 
+      // eslint-disable-next-line no-prototype-builtins
       if (localStorage.hasOwnProperty('accessExpire')) {
         localStorage.removeItem('accessExpire');
       }
@@ -49,6 +51,12 @@ function useAuth() {
         path: '/',
       });
     }
+  }
+
+  function getRefreshToken() {
+    if (refreshToken) return refreshToken;
+
+    return '';
   }
 
   async function reissueToken() {
@@ -68,24 +76,20 @@ function useAuth() {
           token: res.data.refreshToken,
           expire: res.data.refreshExpiration,
         });
-        return;
       } else {
         removeTokens();
-        return;
       }
+      // eslint-disable-next-line no-empty
     } catch {}
   }
 
-  function getRefreshToken() {
-    if (refreshToken) return refreshToken;
-
-    return '';
-  }
-
+  // eslint-disable-next-line consistent-return
   async function getAccessToken() {
     if (
       typeof window !== 'undefined' &&
+      // eslint-disable-next-line no-prototype-builtins
       localStorage.hasOwnProperty('accessToken') &&
+      // eslint-disable-next-line no-prototype-builtins
       localStorage.hasOwnProperty('accessExpire')
     ) {
       const accessTkn = localStorage.getItem('accessToken');
@@ -94,12 +98,11 @@ function useAuth() {
       if (isExpired(accessExp)) {
         if (getRefreshToken()) {
           await reissueToken();
-          const accessTkn = localStorage.getItem('accessToken');
-          return accessTkn;
-        } else {
-          removeTokens();
-          return '';
+          const accessToken = localStorage.getItem('accessToken');
+          return accessToken;
         }
+        removeTokens();
+        return '';
       }
 
       if (!isExpired(accessExp)) return accessTkn;
@@ -108,7 +111,8 @@ function useAuth() {
         await reissueToken();
         const accessTkn = localStorage.getItem('accessToken');
         return accessTkn;
-      } else return '';
+      }
+      return '';
     }
   }
 

--- a/src/lib/CookieProviderWrapper.tsx
+++ b/src/lib/CookieProviderWrapper.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { CookiesProvider } from 'react-cookie';
+
+export default function CookieProviderWrapper({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <CookiesProvider>{children}</CookiesProvider>;
+}

--- a/src/types/user.type.ts
+++ b/src/types/user.type.ts
@@ -1,0 +1,4 @@
+export interface TokenProps {
+  token: string;
+  expire: number;
+}


### PR DESCRIPTION
## 🍋 PR 요약
- 헤더 수정
- 로그인 로직 작업

## ✨ PR 상세 내용
- 헤더 UI 및 값 변경 안 되던 오류 해결
- 로그인 토큰 로직 작업 완료 (다른 방법으로 하고 싶었는데 시간 부족으로 기존 김선배 로직과 유사하게 작업했습니다 🥲)
- 메인 페이지 하단 UI 소폭 수정

## 🚨 주의 사항
- `react-cookie` 설치해서 의존성 설치 다시 해주셔야 합니다!
- 그리고 배포 하면서 알게 된 건데 환경변수 2개의 값이 동일합니다...! 나중에 수정해야 할 것 같습니다 (kakao js 키)
- 시간 부족 + 불가피하게 필요함 이슈로 일부 lint 오류 disable 처리했습니다 ㅠㅠ
- **토큰 로직 동작시키기 전에 localhost:3000에서 `localStorage`, `cookie`에 있는 token들 다 삭제해야 할 겁니당...! 다른 프로젝트에서도 localhost:3000을 쓰니까요!!

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/2042b13e-3c34-4e2b-8f48-04305706780b)

헤더 UI 수정 (링크도 다 연결했는데 recommend 페이지는 아직 구현이 안 돼서 404 뜰 거예용)
현재 로그인 상태라 '로그인' 버튼은 뜨지 않음

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. RAC-1 feat: 기능 추가)
- [ ] 변경 사항에 대한 테스트 진행했나요?
- [x] `npm run format:fix` 실행했나요?
